### PR TITLE
Implement example definition on page load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2019-03-04
+
+### Changed
+
+- Change DefinitionsEditor to a stateful component to support sample code loading
+
+### Added
+
+- Sample broker definition loaded on page load
+
 ## 2019-02-15
 
 ### Changed

--- a/src/components/DefinitionsEditor.tsx
+++ b/src/components/DefinitionsEditor.tsx
@@ -1,32 +1,50 @@
 import * as React from 'react';
 import { UnControlled as CodeMirror } from 'react-codemirror2';
+
 import { ClusterDefinitionContext } from '../store/Contexts';
+import SampleDefinition from '../data/sampleDefinition.json';
 
 // tslint:disable-next-line:no-var-requires
 require('codemirror/mode/javascript/javascript');
 
-const defaultValue = `{
-  "vhosts": [],
-  "parameters": [],
-  "policies": [],
-  "queues": [],
-  "exchanges": [],
-  "bindings": []
-}`;
+interface IEditorState {
+  code: string
+}
 
-const DefinitionsEditor = () => (
-  <ClusterDefinitionContext.Consumer>
-    {clusterDefinition => (
-      <CodeMirror 
-        value={defaultValue}
-        options={{
-          lineNumbers: true,
-          mode: 'javascript',
-          theme: 'material'
-        }}
-        onChange={clusterDefinition.validate} />
-    )}
-  </ClusterDefinitionContext.Consumer>
-);
+class DefinitionsEditor extends React.Component<{}, IEditorState> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      code: ""
+    };
+  }
+
+  public componentDidMount() {
+    // short delay to allow other components to fully render
+    // before setting sample definition
+    setTimeout(() => {
+      this.setState({
+        code: JSON.stringify(SampleDefinition, null, 2)
+      });
+    }, 50);
+  }
+
+  public render() {
+    return (
+      <ClusterDefinitionContext.Consumer>
+        {clusterDefinition => (
+          <CodeMirror 
+            value={this.state.code}
+            options={{
+              lineNumbers: true,
+              mode: 'application/json',
+              theme: 'material'
+            }}
+            onChange={clusterDefinition.validate} />
+        )}
+      </ClusterDefinitionContext.Consumer>
+    );
+  }
+}
 
 export default DefinitionsEditor;

--- a/src/data/sampleDefinition.json
+++ b/src/data/sampleDefinition.json
@@ -1,0 +1,66 @@
+{
+  "vhosts": [{
+    "name": "logs"
+  }],
+  "policies": [{
+    "vhost": "logs",
+    "name": "logs",
+    "pattern": ".*",
+    "apply-to": "all",
+    "definition": {
+      "ha-mode": "all",
+      "ha-sync-mode": "manual"
+    },
+    "priority": 0
+  }],
+  "queues": [{
+    "name": "log",
+    "vhost": "logs",
+    "durable": true,
+    "auto_delete": false,
+    "arguments": {}
+  }, {
+    "name": "critical",
+    "vhost": "logs",
+    "durable": true,
+    "auto_delete": false,
+    "arguments": {}
+  }, {
+    "name": "alert",
+    "vhost": "logs",
+    "durable": true,
+    "auto_delete": false,
+    "arguments": {}
+  }],
+  "exchanges": [{
+    "name": "logs",
+    "vhost": "logs",
+    "type": "topic",
+    "durable": true,
+    "auto_delete": false,
+    "internal": false,
+    "arguments": {}
+  }],
+  "bindings": [{
+    "source": "logs",
+    "vhost": "logs",
+    "destination": "log",
+    "destination_type": "queue",
+    "routing_key": "log.*",
+    "arguments": {}
+  }, {
+    "source": "logs",
+    "vhost": "logs",
+    "destination": "critical",
+    "destination_type": "queue",
+    "routing_key": "*.critical",
+    "arguments": {}
+  }, {
+    "source": "logs",
+    "vhost": "logs",
+    "destination": "alert",
+    "destination_type": "queue",
+    "routing_key": "alert.*",
+    "arguments": {}
+  }]
+}

--- a/src/store/ViewState.ts
+++ b/src/store/ViewState.ts
@@ -15,7 +15,7 @@ const state: IViewState = {
   errors: [],
   selectVhost: (evt, data) => null,
   setZoomFunction: () => null,
-  showRoutingKeys: false,
+  showRoutingKeys: true,
   toggleShowRoutingKeys: () => null,
   zoomToFit: () => null
 };


### PR DESCRIPTION
This adds an example broker definition to the app, which is loaded when the definitions editor component is first mounted. This completes #13.